### PR TITLE
[ESWE-1161] Reconfigure Security jobs (version, schedule, notification/alert)

### DIFF
--- a/.github/workflows/security_owasp.yml
+++ b/.github/workflows/security_owasp.yml
@@ -2,11 +2,11 @@ name: Security OWASP dependency check
 on:
   workflow_dispatch:
   schedule:
-    - cron: "19 6 * * MON-FRI" # Every weekday
+    - cron: "09 5 * * MON-FRI" # Every weekday
 jobs:
   security-kotlin-owasp-check:
     name: Kotlin security OWASP dependency check
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_owasp.yml@v0.7 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_owasp.yml@v1 # WORKFLOW_VERSION
     with:
       channel_id: C05J915DX0Q
     secrets: inherit

--- a/.github/workflows/security_owasp.yml
+++ b/.github/workflows/security_owasp.yml
@@ -8,5 +8,5 @@ jobs:
     name: Kotlin security OWASP dependency check
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_owasp.yml@v1 # WORKFLOW_VERSION
     with:
-      channel_id: C05J915DX0Q
+      channel_id: C028R5FJT4J
     secrets: inherit

--- a/.github/workflows/security_trivy.yml
+++ b/.github/workflows/security_trivy.yml
@@ -8,5 +8,5 @@ jobs:
     name: Project security trivy dependency check
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_trivy.yml@v1 # WORKFLOW_VERSION
     with:
-      channel_id: C05J915DX0Q
+      channel_id: C028R5FJT4J
     secrets: inherit

--- a/.github/workflows/security_trivy.yml
+++ b/.github/workflows/security_trivy.yml
@@ -2,11 +2,11 @@ name: Security trivy dependency check
 on:
   workflow_dispatch:
   schedule:
-    - cron: "19 6 * * MON-FRI" # Every weekday
+    - cron: "09 5 * * MON-FRI" # Every weekday
 jobs:
   security-kotlin-trivy-check:
     name: Project security trivy dependency check
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_trivy.yml@v0.7 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_trivy.yml@v1 # WORKFLOW_VERSION
     with:
       channel_id: C05J915DX0Q
     secrets: inherit

--- a/.github/workflows/security_veracode_pipeline_scan.yml
+++ b/.github/workflows/security_veracode_pipeline_scan.yml
@@ -8,5 +8,5 @@ jobs:
     name: Project security veracode pipeline scan
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_veracode_pipeline_scan.yml@v1 # WORKFLOW_VERSION
     with:
-      channel_id: C05J915DX0Q
+      channel_id: C028R5FJT4J
     secrets: inherit

--- a/.github/workflows/security_veracode_pipeline_scan.yml
+++ b/.github/workflows/security_veracode_pipeline_scan.yml
@@ -2,11 +2,11 @@ name: Security veracode pipeline scan
 on:
   workflow_dispatch:
   schedule:
-    - cron: "19 6 * * MON-FRI" # Every weekday
+    - cron: "09 5 * * MON-FRI" # Every weekday
 jobs:
   security-veracode-pipeline-scan:
     name: Project security veracode pipeline scan
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_veracode_pipeline_scan.yml@v0.7 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_veracode_pipeline_scan.yml@v1 # WORKFLOW_VERSION
     with:
       channel_id: C05J915DX0Q
     secrets: inherit

--- a/.github/workflows/security_veracode_policy_scan.yml
+++ b/.github/workflows/security_veracode_policy_scan.yml
@@ -2,11 +2,11 @@ name: Security veracode policy scan
 on:
   workflow_dispatch:
   schedule:
-    - cron: "34 6 * * 1" # Every Monday
+    - cron: "04 5 * * 1" # Every Monday
 jobs:
   security-veracode-policy-check:
     name: Project security veracode policy scan
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_veracode_policy_scan.yml@v0.7 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_veracode_policy_scan.yml@v1 # WORKFLOW_VERSION
     with:
       channel_id: C05J915DX0Q
     secrets: inherit

--- a/.github/workflows/security_veracode_policy_scan.yml
+++ b/.github/workflows/security_veracode_policy_scan.yml
@@ -8,5 +8,5 @@ jobs:
     name: Project security veracode policy scan
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_veracode_policy_scan.yml@v1 # WORKFLOW_VERSION
     with:
-      channel_id: C05J915DX0Q
+      channel_id: C028R5FJT4J
     secrets: inherit


### PR DESCRIPTION
1. Upgrade GH Actions workflows (Security) to `v1` (from `v0.7`)
2. Revise job schedule (Security scans)
3. Revise notification/alert channel to `#education-skills-work-employment-dev` (was `#hmpps-sre-alerts`)