### PR TITLE
[ESWE-1200] Upgrade dependencies for vulnerability

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "6.1.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "6.1.2"
   kotlin("plugin.spring") version "2.0.21"
 }
 
@@ -7,12 +7,14 @@ configurations {
   testImplementation { exclude(group = "org.junit.vintage") }
 }
 
+ext["logback.version"] = "1.5.15"
+
 dependencies {
-  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:1.1.0")
+  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:1.1.1")
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
 
-  testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:1.1.0")
+  testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:1.1.1")
   testImplementation("org.wiremock:wiremock-standalone:3.9.2")
   testImplementation("io.swagger.parser.v3:swagger-parser:2.1.24") {
     exclude(group = "io.swagger.core.v3")


### PR DESCRIPTION
- upgrade Spring Boot `3.4.1` (was `3.4.0`)
- upgrade HMPPS Spring Boot plugin `6.1.2` (was `6.1.0`)
- upgrade HMPPS Kotlin lib `1.1.1` (was `1.1.0`)
- pin logback version to `1.5.15` (was `1.5.12`)