### PR TITLE
[ESWE-1181] Employer Creation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/config/IntegrationConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/config/IntegrationConfiguration.kt
@@ -5,6 +5,10 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.application.EmployerCreationMessageService
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.application.EmployerRegistrar
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.application.EmployerRetriever
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.domain.EmployerEventType
 import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.domain.IntegrationMessageService
 import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.infrastructure.IntegrationMessageListener
 
@@ -13,7 +17,18 @@ import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.infrastructur
 class IntegrationConfiguration {
   @Bean
   @Qualifier("integrationServiceMap")
-  fun integrationServiceMap(): Map<String, IntegrationMessageService> = emptyMap()
+  fun integrationServiceMap(
+    employerCreationMessageService: EmployerCreationMessageService,
+  ): Map<String, IntegrationMessageService> = mapOf(
+    EmployerEventType.EMPLOYER_CREATED.type to employerCreationMessageService,
+  )
+
+  @Bean
+  fun employerCreationMessageService(
+    retriever: EmployerRetriever,
+    registrar: EmployerRegistrar,
+    objectMapper: ObjectMapper,
+  ) = EmployerCreationMessageService(retriever, registrar, objectMapper)
 
   @Bean
   fun integrationMessageListener(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/application/EmployerMessageServices.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/application/EmployerMessageServices.kt
@@ -1,0 +1,63 @@
+package uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.application
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.domain.EmployerEvent
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.domain.EmployerEventType
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.domain.EmployerEventType.EMPLOYER_CREATED
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.domain.IntegrationEvent
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.domain.IntegrationMessageService
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.infrastructure.MessageAttributes
+
+abstract class EmployerMessageService(
+  employerEventTypes: Set<EmployerEventType>,
+  protected val objectMapper: ObjectMapper,
+) : IntegrationMessageService {
+  constructor(employerEventType: EmployerEventType, objectMapper: ObjectMapper) : this(
+    setOf(employerEventType),
+    objectMapper,
+  )
+
+  protected val eventTypeTypes: Set<String> by lazy { employerEventTypes.map { it.type }.toSet() }
+
+  private companion object {
+    private val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  override fun handleMessage(integrationEvent: IntegrationEvent, messageAttributes: MessageAttributes) {
+    log.info("handle message eventId=${integrationEvent.eventId} eventType=${messageAttributes.eventType}")
+    messageAttributes.eventType?.also {
+      log.trace("handle message. integrationEvent={}", integrationEvent)
+      if (!eventTypeTypes.contains(it)) {
+        throw IllegalArgumentException("Unexpected event type=$it , with eventId=${integrationEvent.eventId}")
+      }
+      handleEvent(integrationEvent.toEmployerEvent())
+    } ?: run {
+      throw IllegalArgumentException("Missing event type eventId=${integrationEvent.eventId}")
+    }
+  }
+
+  protected abstract fun handleEvent(employerEvent: EmployerEvent)
+
+  private fun IntegrationEvent.toEmployerEvent(): EmployerEvent =
+    objectMapper.readValue(content, EmployerEvent::class.java)
+}
+
+class EmployerCreationMessageService(
+  protected val retriever: EmployerRetriever,
+  protected val registrar: EmployerRegistrar,
+  objectMapper: ObjectMapper,
+) : EmployerMessageService(EMPLOYER_CREATED, objectMapper) {
+
+  private companion object {
+    private val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  override fun handleEvent(employerEvent: EmployerEvent) {
+    log.info("handle employer creation event; eventId={}", employerEvent.eventId)
+    retriever.retrieve(employerEvent.employerId).also { employer ->
+      registrar.registerCreation(employer)
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/application/EmployerRegistrar.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/application/EmployerRegistrar.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.application
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.domain.Employer
+
+@Service
+class EmployerRegistrar {
+  fun registerCreation(employer: Employer) {
+    // TODO implement employer registration to MN job-board API
+    throw NotImplementedError("Employer-Creation's registration is not yet implemented!")
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/application/EmployerRetriever.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/application/EmployerRetriever.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.application
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.domain.Employer
+
+@Service
+class EmployerRetriever {
+  fun retrieve(id: String): Employer {
+    // TODO implement employer retrieval from MJMA jobs board API
+    throw NotImplementedError("Employer's retrieval is not yet implemented!")
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/domain/Employer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/domain/Employer.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.domain
+
+import java.time.Instant
+
+data class Employer(
+  var id: String,
+  val name: String,
+  val description: String,
+  val sector: String,
+  val status: String,
+  var createdBy: String? = null,
+  var lastModifiedBy: String? = null,
+  var createdAt: Instant? = null,
+  var lastModifiedAt: Instant? = null,
+) {
+  override fun toString(): String = """
+    Employer(id=$id,
+        name=$name,
+        description=$description,
+        sector=$sector,
+        status=$status,
+        createdBy=$createdBy,
+        createdAt=$createdAt,
+        lastModifiedBy=$lastModifiedBy,
+        lastModifiedAt=$lastModifiedAt
+    )
+  """.trimIndent()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/domain/EmployerEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/domain/EmployerEvent.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.domain
+
+import com.fasterxml.jackson.annotation.JsonValue
+import java.time.Instant
+
+data class EmployerEvent(
+  val eventId: String,
+  val eventType: EmployerEventType,
+  val timestamp: Instant,
+  val employerId: String,
+)
+
+enum class EmployerEventType(val type: String, @JsonValue val eventTypeCode: String, val description: String) {
+  EMPLOYER_CREATED(
+    type = "mjma-jobs-board.employer.created",
+    eventTypeCode = "EmployerCreated",
+    description = "A new employer has been created on the MJMA Jobs Board service",
+  ),
+  EMPLOYER_UPDATED(
+    type = "mjma-jobs-board.employer.updated",
+    eventTypeCode = "EmployerUpdated",
+    description = "An employer has been updated on the MJMA Jobs Board service",
+  ),
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/application/EmployerCreationMessageServiceShould.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/application/EmployerCreationMessageServiceShould.kt
@@ -1,0 +1,65 @@
+package uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.application
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.InjectMocks
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.domain.Employer
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.domain.EmployerEvent
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.domain.EmployerEventType
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.domain.EmployerMother.sainsburys
+
+@ExtendWith(MockitoExtension::class)
+class EmployerCreationMessageServiceShould : EmployerMessageServiceTestCase() {
+
+  @InjectMocks
+  private lateinit var creationService: EmployerCreationMessageService
+
+  @Nested
+  @DisplayName("Given a new employer")
+  inner class GivenANewEmployer {
+    private val employer = sainsburys
+
+    @BeforeEach
+    internal fun setUp() {
+      whenever(mockedObjectMapper.readValue(anyString(), eq(EmployerEvent::class.java))).thenAnswer {
+        objectMapper.readValue(it.arguments[0] as String, EmployerEvent::class.java)
+      }
+      whenever(employerRetriever.retrieve(employer.id)).thenReturn(employer)
+    }
+
+    @Test
+    fun `receive and handle the event of Employer Creation`() {
+      val employerId = sainsburys.id
+      val employerEvent = employerCreationEvent(employerId)
+
+      creationService.handleMessage(employerEvent.toIntegrationEvent(), employerEvent.messageAttributes())
+
+      argumentCaptor<String>().let { captor ->
+        verify(employerRetriever).retrieve(captor.capture())
+        assertEquals(employerId, captor.firstValue)
+      }
+
+      argumentCaptor<Employer>().let { captor ->
+        verify(employerRegistrar).registerCreation(captor.capture())
+        assertEquals(employer, captor.firstValue)
+      }
+    }
+  }
+
+  private fun employerCreationEvent(employerId: String) = EmployerEvent(
+    eventId = randomUUID(),
+    eventType = EmployerEventType.EMPLOYER_CREATED,
+    timestamp = defaultCurrentTime,
+    employerId = employerId,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/application/EmployerMessageServiceTestCase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/application/EmployerMessageServiceTestCase.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.application
+
+import org.mockito.Mock
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.domain.EmployerEvent
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.application.UnitTestBase
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.domain.IntegrationEvent
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.infrastructure.EventType
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.infrastructure.MessageAttributes
+
+abstract class EmployerMessageServiceTestCase : UnitTestBase() {
+  @Mock
+  protected lateinit var employerRetriever: EmployerRetriever
+
+  @Mock
+  protected lateinit var employerRegistrar: EmployerRegistrar
+
+  protected fun EmployerEvent.messageAttributes() = MessageAttributes(this.eventTypeAsAttribute())
+
+  protected fun EmployerEvent.eventTypeAsAttribute() = EventType(this.eventType.type)
+
+  protected fun EmployerEvent.toIntegrationEvent() = IntegrationEvent(
+    eventId = this.eventId,
+    eventType = this.eventType.type,
+    timestamp = this.timestamp,
+    content = objectMapper.writeValueAsString(this),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/domain/EmployerMother.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/domain/EmployerMother.kt
@@ -1,0 +1,43 @@
+package uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.domain
+
+object EmployerMother {
+  val tesco = Employer(
+    id = "89de6c84-3372-4546-bbc1-9d1dc9ceb354",
+    name = "Tesco",
+    description = "Tesco plc is a British multinational groceries and general merchandise retailer headquartered in Welwyn Garden City, England. The company was founded by Jack Cohen in Hackney, London in 1919.",
+    sector = "RETAIL",
+    status = "SILVER",
+  )
+
+  val tescoLogistics = Employer(
+    id = "2c8032bf-e583-4ae9-bcec-968a1c4881f9",
+    name = "Tesco",
+    description = "This is another Tesco employer that provides logistic services.",
+    sector = "LOGISTICS",
+    status = "GOLD",
+  )
+
+  val sainsburys = Employer(
+    id = "f4fbdbf3-823c-4877-aafc-35a7fa74a15a",
+    name = "Sainsbury's",
+    description = "J Sainsbury plc, trading as Sainsbury's, is a British supermarket and the second-largest chain of supermarkets in the United Kingdom. Founded in 1869 by John James Sainsbury with a shop in Drury Lane, London, the company was the largest UK retailer of groceries for most of the 20th century.",
+    sector = "RETAIL",
+    status = "GOLD",
+  )
+
+  val amazon = Employer(
+    id = "bf392249-b360-4e3e-81a0-8497047987e8",
+    name = "Amazon",
+    description = "Amazon.com, Inc., doing business as Amazon, is an American multinational technology company, engaged in e-commerce, cloud computing, online advertising, digital streaming, and artificial intelligence.",
+    sector = "LOGISTICS",
+    status = "KEY_PARTNER",
+  )
+
+  val abcConstruction = Employer(
+    id = "182e9a24-6edb-48a6-a84f-b7061f004a97",
+    name = "ABC Construction",
+    description = "This is a description",
+    sector = "CONSTRUCTION",
+    status = "SILVER",
+  )
+}


### PR DESCRIPTION
- add `EmployerMessageService`, with unit tests
- retriever and registrar are not yet implemented