### PR TITLE
[ESWE-1182] Employer Update

### DIFF
--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/integration/shared/infrastructure/MNJobBoardApiWebClientShould.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/integration/shared/infrastructure/MNJobBoardApiWebClientShould.kt
@@ -9,7 +9,7 @@ import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.domain.Emp
 import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.domain.mnEmployer
 import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.integration.wiremock.MNJobBoardApiExtension.Companion.mnJobBoardApi
-import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.infrastructure.CreatEmployerRequest
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.infrastructure.CreateEmployerRequest
 import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.infrastructure.MNEmployer
 import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.infrastructure.MNJobBoardApiWebClient
 import kotlin.test.assertFailsWith
@@ -19,18 +19,18 @@ class MNJobBoardApiWebClientShould : IntegrationTestBase() {
   @Autowired
   private lateinit var apiWebClient: MNJobBoardApiWebClient
 
+  private val employer = sainsburys
+  private val mnEmployer: MNEmployer get() = employer.copy(createdAt = timeProvider.nowAsInstant()).mnEmployer()
+
   @Nested
   @DisplayName("MN JobBoard `POST` /employers")
   inner class EmployersPostEndpoint {
-    private val employer = sainsburys
-    private val mnEmployer: MNEmployer get() = employer.copy(createdAt = timeProvider.nowAsInstant()).mnEmployer()
-
     @Test
     fun `create employer, with valid details`() {
       val expectedEmployer = mnEmployer.copy(id = 1L)
       mnJobBoardApi.stubCreateEmployer(mnEmployer, expectedEmployer.id!!)
 
-      val actualEmployer = CreatEmployerRequest.from(mnEmployer).let { apiWebClient.createEmployer(it) }
+      val actualEmployer = CreateEmployerRequest.from(mnEmployer).let { apiWebClient.createEmployer(it) }
 
       assertThat(actualEmployer).isEqualTo(expectedEmployer)
     }
@@ -40,7 +40,7 @@ class MNJobBoardApiWebClientShould : IntegrationTestBase() {
       mnJobBoardApi.stubCreateEmployerUnauthorised()
 
       val exception = assertFailsWith<Exception> {
-        CreatEmployerRequest.from(mnEmployer).let { apiWebClient.createEmployer(it) }
+        CreateEmployerRequest.from(mnEmployer).let { apiWebClient.createEmployer(it) }
       }
 
       with(exception) {

--- a/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/integration/wiremock/MNJobBoardApiMockServer.kt
+++ b/src/integrationTest/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/integration/wiremock/MNJobBoardApiMockServer.kt
@@ -30,9 +30,33 @@ class MNJobBoardApiMockServer(
     )
   }
 
+  fun stubUpdateEmployer(mnEmployer: MNEmployer) {
+    val employerUpdated = mnEmployer.copy()
+    stubFor(
+      post("$EMPLOYERS_ENDPOINT/${mnEmployer.id!!}")
+        .withHeader("Authorization", matching("^Bearer .+\$"))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(employerUpdated.response()),
+        ),
+    )
+  }
+
   fun stubCreateEmployerUnauthorised() {
     stubFor(
       post(EMPLOYERS_ENDPOINT)
+        .withHeader("Authorization", matching("^Bearer .+\$"))
+        .willReturn(
+          aResponse()
+            .withStatus(401),
+        ),
+    )
+  }
+
+  fun stubUpdateEmployerUnauthorised(id: Long) {
+    stubFor(
+      post("$EMPLOYERS_ENDPOINT/$id")
         .withHeader("Authorization", matching("^Bearer .+\$"))
         .willReturn(
           aResponse()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/config/IntegrationConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/config/IntegrationConfiguration.kt
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration
 import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.application.EmployerCreationMessageService
 import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.application.EmployerRegistrar
 import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.application.EmployerRetriever
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.application.EmployerUpdateMessageService
 import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.domain.EmployerEventType
 import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.domain.IntegrationMessageService
 import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.infrastructure.IntegrationMessageListener
@@ -18,8 +19,10 @@ class IntegrationConfiguration {
   @Qualifier("integrationServiceMap")
   fun integrationServiceMap(
     employerCreationMessageService: EmployerCreationMessageService,
+    employerUpdateMessageService: EmployerUpdateMessageService,
   ): Map<String, IntegrationMessageService> = mapOf(
     EmployerEventType.EMPLOYER_CREATED.type to employerCreationMessageService,
+    EmployerEventType.EMPLOYER_UPDATED.type to employerUpdateMessageService,
   )
 
   @Bean
@@ -28,6 +31,13 @@ class IntegrationConfiguration {
     registrar: EmployerRegistrar,
     objectMapper: ObjectMapper,
   ) = EmployerCreationMessageService(retriever, registrar, objectMapper)
+
+  @Bean
+  fun employerUpdateMessageService(
+    retriever: EmployerRetriever,
+    registrar: EmployerRegistrar,
+    objectMapper: ObjectMapper,
+  ) = EmployerUpdateMessageService(retriever, registrar, objectMapper)
 
   @Bean
   fun integrationMessageListener(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/application/EmployerMessageServices.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/application/EmployerMessageServices.kt
@@ -45,8 +45,8 @@ abstract class EmployerMessageService(
 }
 
 class EmployerCreationMessageService(
-  protected val retriever: EmployerRetriever,
-  protected val registrar: EmployerRegistrar,
+  private val retriever: EmployerRetriever,
+  private val registrar: EmployerRegistrar,
   objectMapper: ObjectMapper,
 ) : EmployerMessageService(EMPLOYER_CREATED, objectMapper) {
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/application/EmployerMessageServices.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/application/EmployerMessageServices.kt
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory
 import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.domain.EmployerEvent
 import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.domain.EmployerEventType
 import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.domain.EmployerEventType.EMPLOYER_CREATED
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.domain.EmployerEventType.EMPLOYER_UPDATED
 import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.domain.IntegrationEvent
 import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.domain.IntegrationMessageService
 import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.infrastructure.MessageAttributes
@@ -62,6 +63,28 @@ class EmployerCreationMessageService(
       }
     } catch (e: Exception) {
       throw Exception("Error at employer creation event: eventId=${employerEvent.eventId}", e)
+    }
+  }
+}
+
+class EmployerUpdateMessageService(
+  private val retriever: EmployerRetriever,
+  private val registrar: EmployerRegistrar,
+  objectMapper: ObjectMapper,
+) : EmployerMessageService(EMPLOYER_UPDATED, objectMapper) {
+
+  private companion object {
+    private val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  override fun handleEvent(employerEvent: EmployerEvent) {
+    log.info("handle employer update event; eventId={}", employerEvent.eventId)
+    try {
+      retriever.retrieve(employerEvent.employerId).also { employer ->
+        registrar.registerUpdate(employer)
+      }
+    } catch (e: Exception) {
+      throw Exception("Error at employer update event: eventId=${employerEvent.eventId}", e)
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/application/EmployerRegistrar.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/application/EmployerRegistrar.kt
@@ -29,4 +29,18 @@ class EmployerRegistrar(
       }
     }
   }
+
+  fun registerUpdate(employer: Employer) {
+    try {
+      val pendingUpdate = employerService.convertExisting(employer)
+      val updated = employerService.update(pendingUpdate)
+      assert(updated.id == pendingUpdate.id) {
+        "MN Employer ID has changed! employerId=${employer.id}, employerName=${employer.name}; previous ID=${pendingUpdate.id}, new ID=${updated.id}"
+      }
+    } catch (throwable: Throwable) {
+      "Fail to register employer-update; employerId=${employer.id}, employerName=${employer.name}".let { message ->
+        throw Exception(message, throwable)
+      }
+    }
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/application/EmployerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/application/EmployerService.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.domain.JobsBo
 import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.domain.MNJobBoardApiClient
 import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.infrastructure.CreateEmployerRequest
 import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.infrastructure.MNEmployer
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.infrastructure.UpdateEmployerRequest
 
 @ConditionalOnIntegrationEnabled
 @Service
@@ -29,7 +30,21 @@ class EmployerService(
     return mnJobBoardApiClient.createEmployer(request)
   }
 
+  fun update(mnEmployer: MNEmployer): MNEmployer {
+    val request = UpdateEmployerRequest.from(mnEmployer)
+    return mnJobBoardApiClient.updateEmployer(request)
+  }
+
   fun convert(newEmployer: Employer) = convertAndMapId(newEmployer)
+
+  fun convertExisting(existingEmployer: Employer): MNEmployer {
+    val extId = retrieveExternalIdById(existingEmployer.id)
+    return if (extId != null) {
+      convertAndMapId(existingEmployer, extId)
+    } else {
+      throw IllegalStateException("Employer with id=${existingEmployer.id} not found (ID mapping missing)")
+    }
+  }
 
   fun existsIdMappingById(id: String): Boolean = retrieveExternalIdById(id) != null
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/shared/domain/MNJobBoardApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/shared/domain/MNJobBoardApiClient.kt
@@ -2,7 +2,11 @@ package uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.domain
 
 import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.infrastructure.CreateEmployerRequest
 import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.infrastructure.CreateEmployerResponse
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.infrastructure.UpdateEmployerRequest
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.infrastructure.UpdateEmployerResponse
 
 interface MNJobBoardApiClient {
   fun createEmployer(request: CreateEmployerRequest): CreateEmployerResponse
+
+  fun updateEmployer(request: UpdateEmployerRequest): UpdateEmployerResponse
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/shared/domain/MNJobBoardApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/shared/domain/MNJobBoardApiClient.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.domain
 
-import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.infrastructure.CreatEmployerRequest
-import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.infrastructure.CreatEmployerResponse
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.infrastructure.CreateEmployerRequest
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.infrastructure.CreateEmployerResponse
 
 interface MNJobBoardApiClient {
-  fun createEmployer(request: CreatEmployerRequest): CreatEmployerResponse
+  fun createEmployer(request: CreateEmployerRequest): CreateEmployerResponse
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/shared/infrastructure/MNJobBoardApiWebClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/shared/infrastructure/MNJobBoardApiWebClient.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.config.ConditionalOn
 import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.domain.MNJobBoardApiClient
 
 private const val EMPLOYERS_ENDPOINT = "/employers"
+private const val UPDATE_EMPLOYERS_ENDPOINT = "$EMPLOYERS_ENDPOINT/{id}"
 
 @ConditionalOnIntegrationEnabled
 @Service
@@ -32,6 +33,20 @@ class MNJobBoardApiWebClient(
       .onErrorResume { error ->
         val errorResponse = if (error is WebClientResponseException) error.responseBodyAsString else null
         Mono.error(Exception("Fail to create employer! errorResponse=$errorResponse", error))
+      }.block()!!
+      .responseObject
+  }
+
+  override fun updateEmployer(request: UpdateEmployerRequest): UpdateEmployerResponse {
+    log.debug("Updating employer employerName={}, id={}", request.employerName, request.id)
+    log.trace("Update employer request={}", request)
+    return mnJobBoardWebClient.post().uri(UPDATE_EMPLOYERS_ENDPOINT, request.id)
+      .accept(APPLICATION_JSON).body(Mono.just(request), request.javaClass)
+      .retrieve()
+      .bodyToMono(MNUpdateEmployerResponse::class.java)
+      .onErrorResume { error ->
+        val errorResponse = if (error is WebClientResponseException) error.responseBodyAsString else null
+        Mono.error(Exception("Fail to update employer! errorResponse=$errorResponse", error))
       }.block()!!
       .responseObject
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/shared/infrastructure/MNJobBoardApiWebClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/shared/infrastructure/MNJobBoardApiWebClient.kt
@@ -22,13 +22,13 @@ class MNJobBoardApiWebClient(
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  override fun createEmployer(request: CreatEmployerRequest): CreatEmployerResponse {
+  override fun createEmployer(request: CreateEmployerRequest): CreateEmployerResponse {
     log.debug("Creating employer employerName={}", request.employerName)
     log.trace("Create employer request={}", request)
     return mnJobBoardWebClient.post().uri(EMPLOYERS_ENDPOINT)
       .accept(APPLICATION_JSON).body(Mono.just(request), request.javaClass)
       .retrieve()
-      .bodyToMono(MNCreatEmployerResponse::class.java)
+      .bodyToMono(MNCreateEmployerResponse::class.java)
       .onErrorResume { error ->
         val errorResponse = if (error is WebClientResponseException) error.responseBodyAsString else null
         Mono.error(Exception("Fail to create employer! errorResponse=$errorResponse", error))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/shared/infrastructure/MNJobBoardData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/shared/infrastructure/MNJobBoardData.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.infrastructure
 
-data class CreatEmployerRequest(
+data class CreateEmployerRequest(
   val employerName: String,
   val employerBio: String,
   val sectorId: Int,
@@ -10,16 +10,18 @@ data class CreatEmployerRequest(
 ) {
   companion object {
     fun from(employer: MNEmployer) =
-      employer.run { CreatEmployerRequest(employerName, employerBio, sectorId, partnerId, imgName, path) }
+      employer.run { CreateEmployerRequest(employerName, employerBio, sectorId, partnerId, imgName, path) }
   }
 }
 
-typealias CreatEmployerResponse = MNEmployer
+typealias CreateEmployerResponse = MNEmployer
 
-data class MNCreatEmployerResponse(
+data class MNCreateOrUpdateEmployerResponse(
   val message: MNMessage,
   val responseObject: MNEmployer,
 )
+
+typealias MNCreateEmployerResponse = MNCreateOrUpdateEmployerResponse
 
 data class MNEmployer(
   val id: Long? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/shared/infrastructure/MNJobBoardData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/shared/infrastructure/MNJobBoardData.kt
@@ -16,12 +16,30 @@ data class CreateEmployerRequest(
 
 typealias CreateEmployerResponse = MNEmployer
 
+data class UpdateEmployerRequest(
+  val id: Long,
+  val employerName: String,
+  val employerBio: String,
+  val sectorId: Int,
+  val partnerId: Int,
+  val imgName: String? = null,
+  val path: String? = null,
+) {
+  companion object {
+    fun from(employer: MNEmployer) =
+      employer.run { UpdateEmployerRequest(id!!, employerName, employerBio, sectorId, partnerId, imgName, path) }
+  }
+}
+
+typealias UpdateEmployerResponse = MNEmployer
+
 data class MNCreateOrUpdateEmployerResponse(
   val message: MNMessage,
   val responseObject: MNEmployer,
 )
 
 typealias MNCreateEmployerResponse = MNCreateOrUpdateEmployerResponse
+typealias MNUpdateEmployerResponse = MNCreateOrUpdateEmployerResponse
 
 data class MNEmployer(
   val id: Long? = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/application/EmployerRegistrarShould.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/application/EmployerRegistrarShould.kt
@@ -24,16 +24,16 @@ class EmployerRegistrarShould : UnitTestBase() {
   private lateinit var employerRegistrar: EmployerRegistrar
 
   @Nested
-  @DisplayName("Given a valid employer to be registered")
-  inner class GivenAnEmployerToRegister {
+  @DisplayName("Given a new employer to be created at MN")
+  inner class GivenAnEmployerToCreate {
     private val employer = sainsburys
     private val externalId = 1L
     private val mnEmployer = employer.mnEmployer(externalId)
     private val mnEmployerNoId = mnEmployer.copy(id = null)
 
     @Test
-    fun `register a valid employer`() {
-      givenMNEmployerCreated(employer, mnEmployerNoId, mnEmployer)
+    fun `register new employer`() {
+      givenMNEmployerToCreate(employer, mnEmployerNoId, mnEmployer)
 
       employerRegistrar.registerCreation(employer)
 
@@ -54,7 +54,7 @@ class EmployerRegistrarShould : UnitTestBase() {
 
     @Test
     fun `NOT finish registering employer without external ID received`() {
-      givenMNEmployerCreated(employer, mnEmployerNoId, mnEmployerNoId)
+      givenMNEmployerToCreate(employer, mnEmployerNoId, mnEmployerNoId)
 
       val exception = assertFailsWith<Exception> {
         employerRegistrar.registerCreation(employer)
@@ -86,7 +86,7 @@ class EmployerRegistrarShould : UnitTestBase() {
     }
   }
 
-  private fun givenMNEmployerCreated(employer: Employer, convertedEmployer: MNEmployer, mnEmployer: MNEmployer) {
+  private fun givenMNEmployerToCreate(employer: Employer, convertedEmployer: MNEmployer, mnEmployer: MNEmployer) {
     whenever(employerService.existsIdMappingById(employer.id)).thenReturn(false)
     whenever(employerService.convert(employer)).thenReturn(convertedEmployer)
     whenever(employerService.create(convertedEmployer)).thenReturn(mnEmployer)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/application/EmployerRegistrarShould.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/application/EmployerRegistrarShould.kt
@@ -86,9 +86,90 @@ class EmployerRegistrarShould : UnitTestBase() {
     }
   }
 
+  @Nested
+  @DisplayName("Given an existing employer to be updated to MN")
+  inner class GivenAnEmployerToUpdate {
+    private val employer = sainsburys.run { copy(description = "$description |updated") }
+    private val externalId = 1L
+    private val mnEmployer = employer.mnEmployer(externalId)
+
+    @Test
+    fun `update a registered employer`() {
+      givenMNEmployerToUpdate(employer, mnEmployer)
+
+      employerRegistrar.registerUpdate(employer)
+
+      verify(employerService, never()).createIdMapping(externalId, employer.id)
+    }
+
+    @Test
+    fun `throw exception, when external ID has been changed unexpectedly`() {
+      givenMNEmployerToUpdate(employer, mnEmployer, mnEmployer.copy(id = 999L))
+
+      val exception = assertFailsWith<Exception> {
+        employerRegistrar.registerUpdate(employer)
+      }
+
+      with(exception) {
+        assertThat(message).startsWith("Fail to register employer-update").contains("employerId=${employer.id}")
+        with(cause!!) {
+          assertThat(this).isInstanceOfAny(AssertionError::class.java)
+          assertThat(message).startsWith("MN Employer ID has changed!").contains("employerId=${employer.id}")
+        }
+      }
+    }
+
+    @Test
+    fun `throw exception, with error from conversion`() {
+      val expectedException = IllegalStateException("Employer with id=${employer.id} not found (ID mapping missing)")
+      whenever(employerService.convertExisting(employer)).thenThrow(expectedException)
+
+      val actualException = assertFailsWith<Exception> {
+        employerRegistrar.registerUpdate(employer)
+      }
+
+      with(actualException) {
+        assertThat(message).startsWith("Fail to register employer-update").contains("employerId=${employer.id}")
+        with(cause!!) {
+          assertThat(this).isInstanceOfAny(expectedException.javaClass)
+          assertThat(message).isEqualTo(expectedException.message)
+        }
+      }
+    }
+
+    @Test
+    fun `throw exception, with error from updating downstream system`() {
+      val expectedException = "some errors while updating".let {
+        RuntimeException("Fail to update employer! errorResponse=$it", RuntimeException(it))
+      }
+      whenever(employerService.convertExisting(employer)).thenReturn(mnEmployer)
+      whenever(employerService.update(mnEmployer)).thenThrow(expectedException)
+
+      val actualException = assertFailsWith<Throwable> {
+        employerRegistrar.registerUpdate(employer)
+      }
+
+      with(actualException) {
+        assertThat(message).startsWith("Fail to register employer-update").contains("employerId=${employer.id}")
+        with(cause!!) {
+          assertThat(message).isEqualTo(expectedException.message)
+        }
+      }
+    }
+  }
+
   private fun givenMNEmployerToCreate(employer: Employer, convertedEmployer: MNEmployer, mnEmployer: MNEmployer) {
     whenever(employerService.existsIdMappingById(employer.id)).thenReturn(false)
     whenever(employerService.convert(employer)).thenReturn(convertedEmployer)
     whenever(employerService.create(convertedEmployer)).thenReturn(mnEmployer)
+  }
+
+  private fun givenMNEmployerToUpdate(
+    employer: Employer,
+    mnEmployer: MNEmployer,
+    updatedEmployer: MNEmployer = mnEmployer,
+  ) {
+    whenever(employerService.convertExisting(employer)).thenReturn(mnEmployer)
+    whenever(employerService.update(mnEmployer)).thenReturn(updatedEmployer)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/application/EmployerServiceShould.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/application/EmployerServiceShould.kt
@@ -17,7 +17,7 @@ import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.domain.Emp
 import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.refdata.domain.RefData.EmployerSector
 import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.refdata.domain.RefData.EmployerStatus
 import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.application.ServiceTestCase
-import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.infrastructure.CreatEmployerRequest
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.shared.infrastructure.CreateEmployerRequest
 import kotlin.test.assertFailsWith
 
 class EmployerServiceShould : ServiceTestCase() {
@@ -43,66 +43,6 @@ class EmployerServiceShould : ServiceTestCase() {
     }
 
     @Test
-    fun `return true, when external ID exists`() {
-      val id = employer.id
-      givenEmployerExternalIDExists(id, externalId)
-
-      val exists = employerService.existsIdMappingById(id)
-
-      assertThat(exists).isTrue
-    }
-
-    @Test
-    fun `return false, when external ID does not exists`() {
-      val id = employer.id
-      givenEmployerExternalIDNotExist(id)
-
-      employerService.existsIdMappingById(id)
-
-      val exists = employerService.existsIdMappingById(id)
-      assertThat(exists).isFalse()
-    }
-
-    @Test
-    fun `create employer at MN`() {
-      CreatEmployerRequest.from(mnEmployerNoId).let {
-        whenever(mnJobBoardApiClient.createEmployer(it)).thenReturn(mnEmployer)
-      }
-
-      val actualMNEmployer = employerService.create(mnEmployerNoId)
-
-      assertThat(actualMNEmployer).isEqualTo(mnEmployer)
-    }
-
-    @Test
-    fun `convert employer to MN`() {
-      with(employer) { givenRefDataMappings(status, sector) }
-
-      val actualMNEmployer = employerService.convert(employer)
-
-      assertThat(actualMNEmployer).isEqualTo(mnEmployerNoId)
-    }
-
-    @Test
-    fun `create ID mapping, when external ID does not exist`() {
-      val id = employer.id
-      givenEmployerExternalIDNotExist(id)
-      val expectedEmployerId = id
-      val expectedExternalId = externalId
-
-      employerService.createIdMapping(externalId, id)
-
-      val captor = argumentCaptor<EmployerExternalId>()
-      verify(employerExternalIdRepository).save(captor.capture())
-      val savedExternalId = captor.firstValue
-
-      with(savedExternalId.key) {
-        assertThat(id).isEqualTo(expectedEmployerId)
-        assertThat(externalId).isEqualTo(expectedExternalId)
-      }
-    }
-
-    @Test
     fun `NOT create ID mapping, when external ID exists`() {
       val id = employer.id
       givenEmployerExternalIDExists(id, 2)
@@ -116,6 +56,73 @@ class EmployerServiceShould : ServiceTestCase() {
         .contains("id=$id").contains("externalId=$externalId")
 
       verify(employerExternalIdRepository, never()).save(any())
+    }
+
+    @Nested
+    @DisplayName("And has not yet been registered at MN")
+    inner class AndNotYetRegisteredAtMN {
+      @Test
+      fun `return false, when external ID does not exists`() {
+        val id = employer.id
+        givenEmployerExternalIDNotExist(id)
+
+        employerService.existsIdMappingById(id)
+
+        val exists = employerService.existsIdMappingById(id)
+        assertThat(exists).isFalse()
+      }
+
+      @Test
+      fun `convert new employer to MN`() {
+        with(employer) { givenRefDataMappings(status, sector) }
+
+        val actualMNEmployer = employerService.convert(employer)
+
+        assertThat(actualMNEmployer).isEqualTo(mnEmployerNoId)
+      }
+
+      @Test
+      fun `create employer at MN`() {
+        CreateEmployerRequest.from(mnEmployerNoId).let {
+          whenever(mnJobBoardApiClient.createEmployer(it)).thenReturn(mnEmployer)
+        }
+
+        val actualMNEmployer = employerService.create(mnEmployerNoId)
+
+        assertThat(actualMNEmployer).isEqualTo(mnEmployer)
+      }
+
+      @Test
+      fun `create ID mapping, when external ID does not exist`() {
+        givenEmployerExternalIDNotExist(employer.id)
+        val expectedEmployerId = employer.id
+        val expectedExternalId = externalId
+
+        employerService.createIdMapping(externalId, employer.id)
+
+        val captor = argumentCaptor<EmployerExternalId>()
+        verify(employerExternalIdRepository).save(captor.capture())
+        val savedExternalId = captor.firstValue
+
+        with(savedExternalId.key) {
+          assertThat(id).isEqualTo(expectedEmployerId)
+          assertThat(externalId).isEqualTo(expectedExternalId)
+        }
+      }
+    }
+
+    @Nested
+    @DisplayName("And has already been registered at MN")
+    inner class AndAlreadyRegisteredAtMN {
+      @Test
+      fun `return true, when external ID exists`() {
+        val id = employer.id
+        givenEmployerExternalIDExists(id, externalId)
+
+        val exists = employerService.existsIdMappingById(id)
+
+        assertThat(exists).isTrue
+      }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/application/EmployerUpdateMessageServiceShould.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/jobsboardintegrationapi/employers/application/EmployerUpdateMessageServiceShould.kt
@@ -1,0 +1,128 @@
+package uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.application
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.InjectMocks
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.domain.Employer
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.domain.EmployerEvent
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.domain.EmployerEventType
+import uk.gov.justice.digital.hmpps.jobsboardintegrationapi.employers.domain.EmployerObjects.sainsburys
+import kotlin.test.assertFailsWith
+
+@ExtendWith(MockitoExtension::class)
+class EmployerUpdateMessageServiceShould : EmployerMessageServiceTestCase() {
+
+  @InjectMocks
+  private lateinit var updateService: EmployerUpdateMessageService
+
+  @BeforeEach
+  internal fun setUp() {
+    whenever(mockedObjectMapper.readValue(anyString(), eq(EmployerEvent::class.java))).thenAnswer {
+      objectMapper.readValue(it.arguments[0] as String, EmployerEvent::class.java)
+    }
+  }
+
+  @Nested
+  @DisplayName("Given an existing employer")
+  inner class GivenExistingEmployer {
+    private val employer = sainsburys
+
+    @BeforeEach
+    internal fun setUp() {
+      whenever(employerRetriever.retrieve(employer.id)).thenReturn(employer)
+    }
+
+    @Test
+    fun `receive and handle the event of Employer Update`() {
+      val employerId = sainsburys.id
+      val employerEvent = employerUpdateEvent(employerId)
+
+      updateService.handleMessage(employerEvent.toIntegrationEvent(), employerEvent.messageAttributes())
+
+      argumentCaptor<String>().let { captor ->
+        verify(employerRetriever).retrieve(captor.capture())
+        assertEquals(employerId, captor.firstValue)
+      }
+
+      argumentCaptor<Employer>().let { captor ->
+        verify(employerRegistrar).registerUpdate(captor.capture())
+        assertEquals(employer, captor.firstValue)
+      }
+    }
+
+    @Test
+    fun `throw exception, when receive message, but fail to retrieve employer details`() {
+      val causeOfException = RuntimeException("Error retrieving employer details")
+
+      throwsExceptionWhenRetrievingEmployer(causeOfException, employer.id)
+    }
+
+    @Test
+    fun `throw exception, when receive message, but fail to update employer (ID mapping missing)`() {
+      val causeOfException = IllegalStateException("Employer with id=${employer.id} not found (ID mapping missing)")
+
+      throwsExceptionWhenRegisteringUpdate(causeOfException, employer)
+    }
+
+    @Test
+    fun `throw exception, when receive message, but fail to update employer (error updating in downstream)`() {
+      val causeOfException = RuntimeException("Error updating employer at MN")
+
+      throwsExceptionWhenRegisteringUpdate(causeOfException, employer)
+    }
+  }
+
+  @Nested
+  @DisplayName("Given non-existent employer")
+  inner class GivenNonExistentEmployer {
+    @Test
+    fun `throw exception, when receive message, with invalid employer ID`() {
+      val employerId = randomUUID()
+      val causeOfException = IllegalArgumentException("Employer id=$employerId not found")
+      whenever(employerRetriever.retrieve(employerId)).thenThrow(causeOfException)
+
+      throwsExceptionWhenUpdatingEmployer(causeOfException, employerId)
+    }
+  }
+
+  private fun throwsExceptionWhenRetrievingEmployer(causeOfException: Throwable, employerId: String) {
+    whenever(employerRetriever.retrieve(employerId)).thenThrow(causeOfException)
+
+    throwsExceptionWhenUpdatingEmployer(causeOfException, employerId)
+  }
+
+  private fun throwsExceptionWhenRegisteringUpdate(causeOfException: Throwable, employer: Employer) {
+    whenever(employerRegistrar.registerUpdate(employer)).thenThrow(causeOfException)
+
+    throwsExceptionWhenUpdatingEmployer(causeOfException, employer.id)
+  }
+
+  private fun throwsExceptionWhenUpdatingEmployer(causeOfException: Throwable, employerId: String) {
+    val employerEvent = employerUpdateEvent(employerId)
+    val expectedException =
+      Exception("Error at employer update event: eventId=${employerEvent.eventId}", causeOfException)
+
+    val actualException = assertFailsWith<Exception> {
+      updateService.handleMessage(employerEvent.toIntegrationEvent(), employerEvent.messageAttributes())
+    }
+
+    assertEquals(expectedException.message, actualException.message)
+  }
+
+  private fun employerUpdateEvent(employerId: String) = EmployerEvent(
+    eventId = randomUUID(),
+    eventType = EmployerEventType.EMPLOYER_UPDATED,
+    timestamp = defaultCurrentTime,
+    employerId = employerId,
+  )
+}


### PR DESCRIPTION
Refactoring Employer Creation

1. Reorganise unit tests at `EmployerServiceShould`
2. Fix typos at Employer-Creation request

Employer Update

- Implement Employer-Update registration with MN API client