### PR TITLE
[ESWE-1221] Upgrade dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,10 +9,11 @@ configurations {
 }
 
 ext["logback.version"] = "1.5.15"
+ext["json-smart.version"] = "2.5.2"
 
 dependencies {
-  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:1.2.0")
-  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:5.3.0")
+  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:1.2.1")
+  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:5.3.1")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.4")
@@ -38,7 +39,7 @@ testing {
     register<JvmTestSuite>("integrationTest") {
       dependencies {
         kotlin.target.compilations { named("integrationTest") { associateWith(getByName("main")) } }
-        implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:1.2.0")
+        implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:1.2.1")
         implementation("org.wiremock:wiremock-standalone:3.11.0")
         implementation("io.swagger.parser.v3:swagger-parser:2.1.25") {
           exclude(group = "io.swagger.core.v3")


### PR DESCRIPTION
- upgrade HMPPS SQS lib: `5.3.1`
- upgrade HMPPS SB lib: `1.2.1`
- pin `json-smart` to `2.5.2`