### PR TITLE
[ESWE-1217] Retry message on DLQ; Scheduled downtime on non-prod env

### DIFF
--- a/helm_deploy/hmpps-jobs-board-integration-api/values.yaml
+++ b/helm_deploy/hmpps-jobs-board-integration-api/values.yaml
@@ -53,5 +53,8 @@ generic-service:
     groups:
       - internal
 
+  retryDlqCronjob:
+    enabled: true
+
 generic-prometheus-alerts:
   targetApplication: hmpps-jobs-board-integration-api

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -4,6 +4,9 @@
 generic-service:
   replicaCount: 2
 
+  scheduledDowntime:
+    enabled: true
+
   ingress:
     host: jobs-board-integration-api-dev.hmpps.service.justice.gov.uk
 

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -4,6 +4,9 @@
 generic-service:
   replicaCount: 2
 
+  scheduledDowntime:
+    enabled: true
+
   ingress:
     host: jobs-board-integration-api-preprod.hmpps.service.justice.gov.uk
 


### PR DESCRIPTION
1. cron job to retry messages on DLQ (all env)
2. cron job to stop/start for downtime (on `dev`, `preprod`)