### PR TITLE
[ESWE-1252] Resend employers; protect API endpoint at ingress

### DIFF
--- a/helm_deploy/hmpps-jobs-board-integration-api/values.yaml
+++ b/helm_deploy/hmpps-jobs-board-integration-api/values.yaml
@@ -20,6 +20,10 @@ generic-service:
           deny all;
           return 401;
         }
+        location /integration-admin/resend-employers {
+          deny all;
+          return 401;
+        }
 
   # Environment variables to load into the deployment
   env:


### PR DESCRIPTION
Protect API endpoint at Ingress
* Resend employers : /integration-admin/resend-employers