### PR TITLE
[ESWE-1308] Upgrade dependencies; suppress false alarms (OWASP scan)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.0.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.1.0"
   kotlin("plugin.spring") version "2.1.20"
   `jvm-test-suite`
 }
@@ -9,11 +9,11 @@ configurations {
 }
 
 dependencies {
-  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:1.4.2")
-  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:5.4.2")
+  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:1.4.3")
+  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:5.4.4")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("org.springframework.boot:spring-boot-starter-webflux")
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5")
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
 
   runtimeOnly("org.flywaydb:flyway-database-postgresql")
@@ -37,10 +37,11 @@ testing {
     register<JvmTestSuite>("integrationTest") {
       dependencies {
         kotlin.target.compilations { named("integrationTest") { associateWith(getByName("main")) } }
-        implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:1.4.2")
+        implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:1.4.3")
         implementation("org.wiremock:wiremock-standalone:3.12.1")
-        implementation("io.swagger.parser.v3:swagger-parser:2.1.25") {
+        implementation("io.swagger.parser.v3:swagger-parser-v3:2.1.26") {
           exclude(group = "io.swagger.core.v3")
+          exclude(group = "io.swagger.parser.v3", module = "swagger-parser-v2-converter")
           exclude(group = "io.swagger.parser.v3", module = "swagger-parser-safe-url-resolver")
         }
         implementation("org.mockito.kotlin:mockito-kotlin:5.4.0")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/jobs-board-integration-suppressions.xml
+++ b/jobs-board-integration-suppressions.xml
@@ -10,4 +10,20 @@
         <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
         <vulnerabilityName>CVE-2025-26791</vulnerabilityName>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Suppression for false alarm on Swagger Parser wrongly matching Nexus
+        swagger-parser-core-2.1.26.jar (pkg:maven/io.swagger.parser.v3/swagger-parser-core@2.1.26, cpe:2.3:a:project-nexus_project:project-nexus:2.1.26:*:*:*:*:*:*:*, cpe:2.3:a:sonatype:nexus:2.1.26:*:*:*:*:*:*:*) : CVE-2019-7238, CVE-2020-10199, CVE-2020-10204, CVE-2020-10203
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.swagger\.parser\.v3/swagger\-parser\-core@.*$</packageUrl>
+        <cpe>cpe:/a:sonatype:nexus</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Suppression for false alarm on Swagger Parser wrongly matching Nexus
+        swagger-parser-v3-2.1.26.jar (pkg:maven/io.swagger.parser.v3/swagger-parser-v3@2.1.26, cpe:2.3:a:project-nexus_project:project-nexus:2.1.26:*:*:*:*:*:*:*, cpe:2.3:a:sonatype:nexus:2.1.26:*:*:*:*:*:*:*) : CVE-2019-7238, CVE-2020-10199, CVE-2020-10204, CVE-2020-10203
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.swagger\.parser\.v3/swagger\-parser\-v3@.*$</packageUrl>
+        <cpe>cpe:/a:sonatype:nexus</cpe>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
Upgrade dependencies: 
* Spring Boot to `3.4.5` (was `3.4.4`)
* DPS SB plugin to `8.1.0` (was `8.0.0`)
* SQS lib to `5.4.4` (was `5.4.2`)
* Kotlin lib to `1.4.3` (was `1.4.2`)
* Gradle `8.14` (was `8.12.1`)
* Swagger Parser `2.1.26` (was `2.1.25`, for integration tests only)

Suppress false alarms of Swagger Parser matching Nexus issues