### PR TITLE
[ESWE-1414] Upgrade dependencies for OWASP scan's fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.3.7"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "9.0.0"
   kotlin("plugin.spring") version "2.2.10"
-  id("org.owasp.dependencycheck") version "12.1.3"
   `jvm-test-suite`
 }
 


### PR DESCRIPTION
Upgrade:
* Spring Boot plugin `9.0.0` (was `8.3.7`)